### PR TITLE
archlinux build + glm::to_string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 add_library(shaderc_combined_lib INTERFACE)
 if(Vulkan_shaderc_combined_FOUND)
-  target_link_libraries(shaderc_combined_lib Vulkan::shaderc_combined)
+  target_link_libraries(shaderc_combined_lib INTERFACE Vulkan::shaderc_combined)
 else()
   message("Vulkan::shaderc_combined was NOT found!")
   message(" Attempting to set manually...")
@@ -69,57 +69,24 @@ endif()
 ########################################################################
 # For spirv-cross
 add_library(spirv-cross INTERFACE)
-
-add_library(spirv-cross-c_lib STATIC IMPORTED)
-set_target_properties(spirv-cross-c_lib PROPERTIES
-  IMPORTED_LOCATION "/usr/lib/x86_64-linux-gnu/libspirv-cross-c.a"
-  INTERFACE_INCLUDE_DIRECTORIES "/usr/include"
-)
-add_library(spirv-cross-core_lib STATIC IMPORTED)
-set_target_properties(spirv-cross-core_lib PROPERTIES
-  IMPORTED_LOCATION "/usr/lib/x86_64-linux-gnu/libspirv-cross-core.a"
-  INTERFACE_INCLUDE_DIRECTORIES "/usr/include"
-)
-add_library(spirv-cross-cpp_lib STATIC IMPORTED)
-set_target_properties(spirv-cross-cpp_lib PROPERTIES
-  IMPORTED_LOCATION "/usr/lib/x86_64-linux-gnu/libspirv-cross-cpp.a"
-  INTERFACE_INCLUDE_DIRECTORIES "/usr/include"
-)
-add_library(spirv-cross-glsl_lib STATIC IMPORTED)
-set_target_properties(spirv-cross-glsl_lib PROPERTIES
-  IMPORTED_LOCATION "/usr/lib/x86_64-linux-gnu/libspirv-cross-glsl.a"
-  INTERFACE_INCLUDE_DIRECTORIES "/usr/include"
-)
-add_library(spirv-cross-hlsl_lib STATIC IMPORTED)
-set_target_properties(spirv-cross-hlsl_lib PROPERTIES
-  IMPORTED_LOCATION "/usr/lib/x86_64-linux-gnu/libspirv-cross-hlsl.a"
-  INTERFACE_INCLUDE_DIRECTORIES "/usr/include"
-)
-add_library(spirv-cross-msl_lib STATIC IMPORTED)
-set_target_properties(spirv-cross-msl_lib PROPERTIES
-  IMPORTED_LOCATION "/usr/lib/x86_64-linux-gnu/libspirv-cross-msl.a"
-  INTERFACE_INCLUDE_DIRECTORIES "/usr/include"
-)
-add_library(spirv-cross-reflect_lib STATIC IMPORTED)
-set_target_properties(spirv-cross-reflect_lib PROPERTIES
-  IMPORTED_LOCATION "/usr/lib/x86_64-linux-gnu/libspirv-cross-reflect.a"
-  INTERFACE_INCLUDE_DIRECTORIES "/usr/include"
-)
-add_library(spirv-cross-util_lib STATIC IMPORTED)
-set_target_properties(spirv-cross-util_lib PROPERTIES
-  IMPORTED_LOCATION "/usr/lib/x86_64-linux-gnu/libspirv-cross-util.a"
-  INTERFACE_INCLUDE_DIRECTORIES "/usr/include"
-)
+find_library(spirv-cross-c_lib spirv-cross-c)
+find_library(spirv-cross-core_lib spirv-cross-core)
+find_library(spirv-cross-cpp_lib spirv-cross-cpp)
+find_library(spirv-cross-glsl_lib spirv-cross-glsl)
+find_library(spirv-cross-hlsl_lib spirv-cross-hlsl)
+find_library(spirv-cross-msl_lib spirv-cross-msl)
+find_library(spirv-cross-reflect_lib spirv-cross-reflect)
+find_library(spirv-cross-util_lib spirv-cross-util)
 
 target_link_libraries(spirv-cross INTERFACE
-  spirv-cross-c_lib
-  spirv-cross-core_lib
-  spirv-cross-cpp_lib
-  spirv-cross-glsl_lib
-  spirv-cross-hlsl_lib
-  spirv-cross-msl_lib
-  spirv-cross-reflect_lib
-  spirv-cross-util_lib
+  ${spirv-cross-c_lib}
+  ${spirv-cross-core_lib}
+  ${spirv-cross-cpp_lib}
+  ${spirv-cross-glsl_lib}
+  ${spirv-cross-hlsl_lib}
+  ${spirv-cross-msl_lib}
+  ${spirv-cross-reflect_lib}
+  ${spirv-cross-util_lib}
 )
 
 ########################################################################
@@ -288,6 +255,9 @@ target_link_libraries(HZ_Hazel_Scripting
 
 target_link_libraries(HZ_Platform_OpenGL
   Vulkan::Vulkan shaderc_combined_lib spirv-cross
+  Vulkan::glslang
+  Vulkan::SPIRV-Tools
+  SPIRV-Tools-opt
 )
 
 target_link_libraries(HZ_Hazel_Core

--- a/Hazel/src/Hazel/Scripting/ScriptGlue.cpp
+++ b/Hazel/src/Hazel/Scripting/ScriptGlue.cpp
@@ -30,13 +30,13 @@ namespace Hazel {
 
 	static void NativeLog_Vector(glm::vec3* parameter, glm::vec3* outResult)
 	{
-		HZ_CORE_WARN("Value: {0}", *parameter);
+		HZ_CORE_WARN("Value: {0}", glm::to_string(*parameter));
 		*outResult = glm::normalize(*parameter);
 	}
 
 	static float NativeLog_VectorDot(glm::vec3* parameter)
 	{
-		HZ_CORE_WARN("Value: {0}", *parameter);
+		HZ_CORE_WARN("Value: {0}", glm::to_string(*parameter));
 		return glm::dot(*parameter, *parameter);
 	}
 

--- a/linuxScripts/ArchSetup.sh
+++ b/linuxScripts/ArchSetup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# For Arch
+
+if ! [ $(id -u) -eq 0 ]
+then
+        echo "this script must run as root"
+        exit 1
+fi
+
+set -e # Stop if an error is detected
+
+aurdeps="spirv-cross"
+
+echo -e "install the following dependencies using your aur helper:\n\t$aurdeps\n"
+echo "once done press any key to continue"
+read
+pacman -Q spirv-cross
+pacman -S mono vulkan-devel
+
+echo "setup done. now run ./compile.sh"


### PR DESCRIPTION
#### archlinux build + glm::to_string
- Added arch dependencies script in `linuxScripts/ArchSetup.sh`
- find_library for spirv-cross libs instead of hardcoding
- link Vulkan::glslang, Vulkan::SPIRV-Tools and SPIRV-Tools-opt
- Convert glm::vec to strings before logging with spdlog